### PR TITLE
Fix rounding in BigInteger computation

### DIFF
--- a/PiEstimator/Program.cs
+++ b/PiEstimator/Program.cs
@@ -44,7 +44,14 @@
             BigInteger pi = 3 * multiplier;
             for (BigInteger i = 2; i < int.MaxValue; i += 2)
             {
-                BigInteger delta = multiplier * sign * 4 / (i * (i + 1) * (i + 2));
+                BigInteger denominator = i * (i + 1) * (i + 2);
+                BigInteger numerator = multiplier * 4;
+                BigInteger quotient = BigInteger.DivRem(numerator, denominator, out BigInteger remainder);
+                BigInteger delta = sign * quotient;
+                if (remainder * 2 >= denominator)
+                {
+                    delta += sign;
+                }
                 pi = pi + delta;
 
                 if ((int) i % 10000000 == 0)


### PR DESCRIPTION
## Summary
- prevent truncation when computing the Nilakantha series using BigInteger

## Testing
- `dotnet build PiEstimator/PiEstimator.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851cccc9158832fa7069f34a43bf3c7